### PR TITLE
[FEAT] 동화 내용 기반 이미지 생성 기능 구현

### DIFF
--- a/src/main/java/com/futurenet/sorisoopbackend/customfairytale/application/MakeFairyTaleServiceImpl.java
+++ b/src/main/java/com/futurenet/sorisoopbackend/customfairytale/application/MakeFairyTaleServiceImpl.java
@@ -13,10 +13,15 @@ import com.futurenet.sorisoopbackend.global.exception.RestApiException;
 import com.futurenet.sorisoopbackend.global.infrastructure.service.AmazonS3Service;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.openai.OpenAiImageModel;
+import org.springframework.ai.openai.OpenAiImageOptions;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MimeType;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -28,10 +33,12 @@ public class MakeFairyTaleServiceImpl implements MakeFairyTaleService {
 
     private final AmazonS3Service amazonS3Service;
     private final ChatClient chatClient;
+    private final OpenAiImageModel openAiImageModel;
 
-    public MakeFairyTaleServiceImpl(AmazonS3Service amazonS3Service, ChatClient.Builder chatClientBuilder) {
+    public MakeFairyTaleServiceImpl(AmazonS3Service amazonS3Service, ChatClient.Builder chatClientBuilder, OpenAiImageModel openAiImageModel) {
         this.amazonS3Service = amazonS3Service;
         this.chatClient = chatClientBuilder.build();
+        this.openAiImageModel = openAiImageModel;
     }
 
     @Override
@@ -51,17 +58,49 @@ public class MakeFairyTaleServiceImpl implements MakeFairyTaleService {
                     .orElseThrow(() -> new RestApiException(GlobalErrorCode.INVALID_CONTENT_TYPE));
 
             ChatResponse chatResponse = chatClient.prompt()
-                    .user(u -> u
-                            .text(prompt)
-                            .media(mimeType, imageUrl)
-                    )
+                    .user(u -> u.text(prompt).media(mimeType, imageUrl))
                     .call()
                     .chatResponse();
+
+            if (chatResponse == null) {
+                throw new CustomFairyTaleException(CustomFairyTaleErrorCode.OPENAI_SCRIPT_RESPONSE_NULL);
+            }
 
             String resultJson = chatResponse.getResult().getOutput().getText();
 
             ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(resultJson, new TypeReference<List<MakeCustomFairyTaleResponse>>() {});
+            List<MakeCustomFairyTaleResponse> pages = objectMapper.readValue(resultJson, new TypeReference<List<MakeCustomFairyTaleResponse>>() {});
+
+            for (MakeCustomFairyTaleResponse page : pages) {
+                String imagePrompt = OpenAIPromptUtil.makeCustomFairyTaleImagePrompt(page.getContent());
+
+                try {
+                    ImageResponse imageResponse = openAiImageModel.call(
+                            new ImagePrompt(imagePrompt, OpenAiImageOptions.builder()
+                                    .quality("standard")
+                                    .N(1)
+                                    .width(1024)
+                                    .height(1024)
+                                    .build()
+                            )
+                    );
+
+                    String imageUrlFromOpenAI = imageResponse.getResult().getOutput().getUrl();
+
+                    try (InputStream openAiImageStream = URI.create(imageUrlFromOpenAI).toURL().openStream()) {
+                        String s3Url = amazonS3Service.uploadImage(
+                                openAiImageStream,
+                                FolderNameConstant.CUSTOM_FAIRY_TALE,
+                                "png"
+                        );
+                        page.setImageUrl(s3Url);
+                    }
+                } catch (Exception e) {
+                    throw new CustomFairyTaleException(CustomFairyTaleErrorCode.OPENAI_IMAGE_GENERATE_FAIL);
+                }
+            }
+
+            return pages;
 
         } catch (MalformedURLException e) {
             throw new RestApiException(GlobalErrorCode.INVALID_URL);

--- a/src/main/java/com/futurenet/sorisoopbackend/customfairytale/application/exception/CustomFairyTaleErrorCode.java
+++ b/src/main/java/com/futurenet/sorisoopbackend/customfairytale/application/exception/CustomFairyTaleErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum CustomFairyTaleErrorCode implements ErrorCode {
 
-    IMAGE_FILE_NULL("CF000", "이미지가 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+    IMAGE_FILE_NULL("CF000", "이미지가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    OPENAI_SCRIPT_RESPONSE_NULL("CF001", "스크립트 생성 결과가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    OPENAI_IMAGE_GENERATE_FAIL("CF002", "동화 이미지 생성을 실패했습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/futurenet/sorisoopbackend/customfairytale/infrastructure/util/OpenAIPromptUtil.java
+++ b/src/main/java/com/futurenet/sorisoopbackend/customfairytale/infrastructure/util/OpenAIPromptUtil.java
@@ -16,4 +16,17 @@ public class OpenAIPromptUtil {
         -  ``` json ``` 이런거도 다 빼고 오로지 [{ "page": 1, "content": "..." }, ... ] 양식으로만
         """, age);
     }
+
+    public static String makeCustomFairyTaleImagePrompt(String content) {
+        return String.format("""
+        Create a children's book style illustration for the following scene:
+
+        "%s"
+
+        - Use a warm, soft, and dreamy watercolor or pastel style
+        - The illustration should match the atmosphere of the scene
+        - Emphasize a magical and emotional tone suitable for kids
+        - Keep the visual style consistent with the rest of the story
+        """, content);
+    }
 }

--- a/src/main/java/com/futurenet/sorisoopbackend/global/constant/FolderNameConstant.java
+++ b/src/main/java/com/futurenet/sorisoopbackend/global/constant/FolderNameConstant.java
@@ -2,4 +2,5 @@ package com.futurenet.sorisoopbackend.global.constant;
 
 public class FolderNameConstant {
     public static final String USER_DRAWING = "user-drawings";
+    public static final String CUSTOM_FAIRY_TALE = "custom-fairytale";
 }

--- a/src/main/java/com/futurenet/sorisoopbackend/global/infrastructure/service/AmazonS3Service.java
+++ b/src/main/java/com/futurenet/sorisoopbackend/global/infrastructure/service/AmazonS3Service.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.UUID;
 
 @Service
@@ -29,6 +30,7 @@ public class AmazonS3Service {
         }
 
         try {
+
             String fileName = folder + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentType(file.getContentType());
@@ -38,6 +40,21 @@ public class AmazonS3Service {
 
             return amazonS3.getUrl(bucket, fileName).toString();
         } catch (IOException e) {
+            throw new InfrastructureException(InfrastructureErrorCode.S3_FILE_UPLOAD_FAIL);
+        }
+    }
+
+    public String uploadImage(InputStream inputStream, String folder, String extension) {
+        try {
+            String fileName = folder + "/" + UUID.randomUUID() + "." + extension;
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType("image/" + extension);
+
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
+
+            return amazonS3.getUrl(bucket, fileName).toString();
+        } catch (Exception e) {
             throw new InfrastructureException(InfrastructureErrorCode.S3_FILE_UPLOAD_FAIL);
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,8 +11,11 @@ spring:
       api-key: ${OPEN_AI_KEY}
       chat:
         options:
-          model: "gpt-4o"
+          model: gpt-4o
           temperature: 0.7
+      image:
+        options:
+          model: dall-e-3
 
 cloud:
   aws:


### PR DESCRIPTION
<!-- 제목 입력하기 -->
<!-- [FEAT/CHORE/FIX/DOCS/REFACTOR] 기능제목 -->


<!-- 주석 부분 모두 지우고 작성 -->
## ✈️ 브랜치
 - feat/custom-fairy-tale/image -> main

## 🔗 변경 사항
 - ISSUE #5 

## ✔️ 테스트
 - [x] 대본 기반 이미지 생성 테스트
 - [x] 생성된 이미지 s3 저장 테스트

## 📷 스크린샷
<!-- postman 결과나 동작하는 화면 캡처 -->
<img width="1554" height="738" alt="image" src="https://github.com/user-attachments/assets/581c3e65-ade7-496f-81f7-0fe4c92a7789" />
<img width="914" height="936" alt="image" src="https://github.com/user-attachments/assets/5148452a-a926-4853-b785-1e2f1ae2e5e1" />


<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #5  -->
